### PR TITLE
Setup: create test helper file with SimpleCov and Minitest requires

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,5 @@
+require 'simplecov'
+SimpleCov.start
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'mocha/minitest'


### PR DESCRIPTION
The test helper file contains requires that can be called on other tests.
This creates a more efficient workflow, as you would have to include all of your requires each time for each test file you create that utilizes them.